### PR TITLE
Support attachment playback, history, and sequential playlist loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,16 @@
 ・キューのクリア  
 ・現在再生中の曲に関する情報の表示  
 ・曲の存在確認  
-・音量調節  
-・pingの確認  
-・曲指定スキップ  
+・音量調節
+・再生位置の変更(シーク)
+・pingの確認
+・曲指定スキップ
 ・曲指定スキップの際にもしキューループが有効な場合はスキップした曲をキューの末尾に追加する
-・キューのシャッフル  
+・キューのシャッフル
+・添付ファイルからの再生(リンクは2時間で無効)
+・再生履歴の表示と履歴からの再生
 ・プレイリストのサポート(v1.1.0以降から正式サポート)
-・youtube APIを使用しない曲の検索機能(v1.2.0以降から正式サポート)  
+・youtube APIを使用しない曲の検索機能(v1.2.0以降から正式サポート)
 ・VCに参加している人が0人になったら自動で退出(v1.2.0以降から正式サポート)  
 ・一度取得したデータを保持しておくことで再取得の手間をなくしネットワーク負荷の軽減と再生までの時間を高速化(v1.3.0以降から正式サポート)  
 ・メモリがひっ迫した際に自動でキャッシュをクリア(v1.3.0以降から正式サポート)   
@@ -73,13 +76,16 @@ The bot called SakuraMusic described in [article](https://qiita.com/_yussy_/item
 ・Clear queue  
 ・Display information about the currently playing song  
 ・Confirming the existence of a song  
-・Volume control  
-・Ping confirmation  
-・Skip to a specific song  
-・If a queue loop is enabled when a song is skipped, the skipped song will be added to the end of the queue.  
-・Shuffle queue  
-・playlist support(officially supported since v1.2.0)  
-・Search function for songs without using youtube API (officially supported since v1.2.0)  
+・Volume control
+・Seek within the current track
+・Ping confirmation
+・Skip to a specific song
+・If a queue loop is enabled when a song is skipped, the skipped song will be added to the end of the queue.
+・Shuffle queue
+・Play from audio attachments (links expire after 2 hours)
+・View playback history and replay songs from it
+・playlist support(officially supported since v1.2.0)
+・Search function for songs without using youtube API (officially supported since v1.2.0)
 ・Automatic exit from VC when the number of participants reaches zero (officially supported since v1.2.0)  
 ・Retain data once acquired to reduce network load and speed up playback time (officially supported since v1.3.0)  
 ・Automatic cache clearing when memory is overloaded (officially supported since v1.3.0)  

--- a/index.js
+++ b/index.js
@@ -5,12 +5,11 @@ try {
     var ytpl = require('ytpl');
     var playdl = require("play-dl")
     var streamer = require('yt-dlp-wrap').default;
-    var cluster = require('cluster');
-    var { cpus } = require('os');
     var os = require('os');
     var cron = require('node-cron');
     var events = require('events');
     var fs = require('fs');
+    var path = require('path');
     var { https } = require('follow-redirects');
     var  stream  = require('stream');
     var ytdl = require('ytdl-core');
@@ -33,21 +32,16 @@ try {
     });
 
 }
+const MusicQueue = require('./src/MusicQueue');
+const Song = require('./src/Song');
+const { toHms, parseTime } = require('./src/utils');
 const EventEmitter = events.EventEmitter;
 const ee = new EventEmitter();
-const numCPUs = cpus().length;
 require('dotenv').config();
 process.env['YTDL_NO_UPDATE'] = true;
 
-if (cluster.isPrimary) {
-    cacheEnabled = true;
-    ramUsageReportEnabled = false;
-    multiCoreScale = 1;
-
-    if (process.env.multiCoreScale) {
-        multiCoreScale = parseInt(process.env.multiCoreScale);
-        if (multiCoreScale < 1) multiCoreScale = 1;
-    }
+let cacheEnabled = true;
+let ramUsageReportEnabled = false;
 
     if (process.env.cacheEnabled == "false") {
         cacheEnabled = false;
@@ -92,142 +86,24 @@ if (cluster.isPrimary) {
         return v
     }
     let musicInfoCache = new Map();
-    let temp = {};
-    let Index = {};
-    let active = {};
-    let count = {};
-    let allcount = {};
-    let fallcount = {};
-    client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildVoiceStates] });
+    let client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildVoiceStates] });
 
-    token = process.env.token
-    queue = new Map();
+    const token = process.env.token
+    const queue = new Map();
 
-    rebootFLG = false;
+    let rebootFLG = false;
 
-    commandList = [
-        {
-            name: 'play',
-            description: 'Play music from Youtube',
-            type: ApplicationCommandType.ChatInput,
-            options: [
-                {
-                    name: 'video_info',
-                    description: 'Youtube URL or Search Query',
-                    type: ApplicationCommandOptionType.String,
-                    required: true
-                }
-            ]
-        },
-        {
-            name: 'skip',
-            description: 'Skip the music',
-            type: ApplicationCommandType.ChatInput,
-        },
-        {
-            name: 'stop',
-            description: 'Stop the music',
-            type: ApplicationCommandType.ChatInput,
-        },
-        {
-            name: 'queue',
-            description: 'Show the queue',
-            type: ApplicationCommandType.ChatInput,
-        },
-        {
-            name: 'nowplaying',
-            description: 'Show the song you are playing',
-            type: ApplicationCommandType.ChatInput,
-        },
-        {
-            name: 'loop',
-            description: 'Loop the song',
-            type: ApplicationCommandType.ChatInput,
-        },
-        {
-            name: 'queueloop',
-            description: 'Loop the queue',
-            type: ApplicationCommandType.ChatInput,
-        },
-        {
-            name: 'pause',
-            description: 'Pause the music',
-            type: ApplicationCommandType.ChatInput,
-        },
-        {
-            name: 'resume',
-            description: 'Resume the music',
-            type: ApplicationCommandType.ChatInput,
-        },
-        {
-            name: 'volume',
-            description: 'Change the volume',
-            type: ApplicationCommandType.ChatInput,
-            options: [
-                {
-                    name: 'volume',
-                    description: 'Volume',
-                    type: ApplicationCommandOptionType.String,
-                    required: true
-                }
-            ]
-        },
-        {
-            name: 'remove',
-            description: 'Remove the song from the queue',
-            type: ApplicationCommandType.ChatInput,
-            options: [
-                {
-                    name: 'songnumber',
-                    description: 'Index',
-                    type: ApplicationCommandOptionType.String,
-                    required: true
-                }
-            ]
-        },
-        {
-            name: 'shuffle',
-            description: 'Shuffle the queue',
-            type: ApplicationCommandType.ChatInput,
-        },
-        {
-            name: 'clear',
-            description: 'Clear the queue',
-            type: ApplicationCommandType.ChatInput,
-        },
-        {
-            name: 'skipto',
-            description: 'Skip to the song',
-            type: ApplicationCommandType.ChatInput,
-            options: [
-                {
-                    name: 'songnumber',
-                    description: 'Index',
-                    type: ApplicationCommandOptionType.String,
-                    required: true
-                }
-            ]
-        },
-        {
-            name: 'help',
-            description: 'Show the help',
-            type: ApplicationCommandType.ChatInput,
-        },
-        {
-            name: 'ping',
-            description: 'Show the ping',
-            type: ApplicationCommandType.ChatInput,
-        },
-        {
-            name: 'invite',
-            description: 'Invite SakuraMusicV2 to your server',
-            type: ApplicationCommandType.ChatInput,
-        },
-        {
-            name: 'autoplay',
-            description: 'Autoplay the music if the queue is empty',
-        }
-    ];
+    const commands = new Map();
+    let commandList = [];
+    const commandFiles = fs.readdirSync(path.join(__dirname, 'src/Commands')).filter(file => file.endsWith('.js') && file !== 'BaseCommand.js');
+    for (const file of commandFiles) {
+        const CommandClass = require(`./src/Commands/${file}`);
+        const command = new CommandClass();
+        commands.set(command.data.name, command);
+        commandList.push(command.data);
+    }
+
+    const context = { queue, MusicQueue, Song, parseTime, toHms, musicInfoCache, cacheEnabled, client };
 
     let yt_dlp_filename = "";
 
@@ -340,21 +216,20 @@ if (cluster.isPrimary) {
             let queuedata = JSON.parse(fs.readFileSync('./queue.json', 'utf8'));
             if (queuedata.length == 0) return new Map();
             queuedata.forEach((value) => {
-                queueContruct = {
-                    textChannel: client.channels.cache.get(value.textChannel),
-                    voiceChannel: client.channels.cache.get(value.voiceChannel),
-                    connection: null,
-                    songs: value.songs,
-                    playing: value.playing,
-                    loop: value.loop,
-                    queueloop: value.queueloop,
-                    player: null,
-                    resource: null,
-                    paused: value.paused,
-                    autoPlay: value.autoPlay,
-                    autoPlayPosition: value.autoPlayPosition,
-                    starttimestamp: value.starttimestamp
-                };
+                const queueContruct = new MusicQueue(
+                    client.channels.cache.get(value.textChannel),
+                    client.channels.cache.get(value.voiceChannel)
+                );
+                queueContruct.songs = value.songs;
+                queueContruct.playing = value.playing;
+                queueContruct.loop = value.loop;
+                queueContruct.queueloop = value.queueloop;
+                queueContruct.player = null;
+                queueContruct.resource = null;
+                queueContruct.paused = value.paused;
+                queueContruct.autoPlay = value.autoPlay;
+                queueContruct.autoPlayPosition = value.autoPlayPosition;
+                queueContruct.starttimestamp = value.starttimestamp;
                 if (queueContruct.songs.length == 0) return;
                 if (queueContruct.textChannel == null || queueContruct.voiceChannel == null) return;
                 queue.set(value.key, queueContruct);
@@ -380,458 +255,13 @@ if (cluster.isPrimary) {
     client.on('interactionCreate', async interaction => {
         if (!interaction.isCommand()) return;
         await interaction.deferReply();
-
-        switch (interaction.commandName) {
-            case 'play':
-
-                voiceChannel = interaction.member.voice.channel;
-
-                if (!voiceChannel) return interaction.followUp('You need to be in a voice channel to play music!');
-
-                permissions = voiceChannel.permissionsFor(interaction.client.user);
-
-                if (!permissions.has(PermissionFlagsBits.Connect) || !permissions.has(PermissionFlagsBits.Speak)) {
-                    return interaction.followUp("I need the permissions to join and speak in your voice channel!");
-                }
-                
-
-                var musiclist = [];
-                serverQueue = queue.get(interaction.guild.id);
-                url = interaction.options.getString('video_info');
-                if (url.includes('list=') && !url.includes('watch?v=')) {
-                    playlist = await ytpl(url, { limit: Infinity }).catch(error => {
-                        console.log(error)
-                        interaction.followUp("Oops, there seems to have been an error.\nPlease check the following points.\n*Is the URL correct?\n*Are you using a Youtube URL?\n*Is the URL shortened? \nIf the problem still persists, please wait a while and try again.")
-                    });
-
-                    if (!playlist) return interaction.followUp("Oops, there seems to have been an error.\nPlease check the following points.\n*Is the URL correct?\n*Are you using a Youtube URL?\n*Is the URL shortened? \nIf the problem still persists, please wait a while and try again.");
-
-                    musiclist.push(...playlist.items.map(x => x.url.substring(0, x.url.indexOf("&list="))));
-
-                } else {
-                    errorFLG = false;
-                    if (!url.includes('youtube.com') && !url.includes('youtu.be/')) {
-                        let yt_info = await playdl.search(url, {
-                            limit: 1
-                        }).catch(async error => {
-                            errorFLG = true;
-                            return interaction.followUp("Oops, there seems to have been an error.\nPlease check the following points.\n*Is the URL correct?\n*Are you using a URL other than Youtube?\n*Is the URL shortened? \nIf the problem still persists, please wait a while and try again.")
-                        });
-                        if (errorFLG) return;
-                        if (yt_info.length == 0) return interaction.followUp("Oops, there seems to have been an error.\nPlease check the following points.\n*Is the URL correct?\n*Are you using a URL other than Youtube?\n*Is the URL shortened? \nIf the problem still persists, please wait a while and try again.")
-                        url = yt_info[0].url
-                    }
-                    musiclist.push(url)
-                }
-                songs = [];
-                if (!musicInfoCache.has(musiclist[0])) {
-                    songInfo = await ytdl.getInfo(musiclist.shift()).catch(async error => {
-                    });
-
-                    if (!songInfo) {
-                        return interaction.followUp("Oops, there seems to have been an error.\nPlease check the following points.\n*Is the URL correct?\n*Are you using a URL other than Youtube?\n*Is the URL shortened? \nIf the problem still persists, please wait a while and try again.")
-                    }
-                    song = {
-                        title: songInfo.videoDetails.title,
-                        url: songInfo.videoDetails.video_url,
-                        totalsec: songInfo.videoDetails.lengthSeconds,
-                        viewcount: songInfo.videoDetails.viewCount,
-                        author: {
-                            name: songInfo.videoDetails.author.name,
-                            url: songInfo.videoDetails.author.channel_url,
-                            subscriber_count: songInfo.videoDetails.author.subscriber_count,
-                            verified: songInfo.videoDetails.author.verified
-                        },
-                        thumbnail: songInfo.videoDetails.thumbnails[Object.keys(songInfo.videoDetails.thumbnails).length - 1].url
-                    };
-
-                    if (cacheEnabled) musicInfoCache.set(songInfo.videoDetails.video_url, song)
-                } else {
-                    song = musicInfoCache.get(musiclist.shift())
-                }
-                if (!serverQueue) {
-
-                    queueContruct = {
-                        textChannel: interaction.channel,
-                        voiceChannel: voiceChannel,
-                        connection: null,
-                        songs: [],
-                        playing: true,
-                        loop: false,
-                        queueloop: false,
-                        starttimestamp: 0,
-                        player: null,
-                        resource: null,
-                        paused: false,
-                        autoPlay: false,
-                        autoPlayPosition: 1
-                    };
-
-
-
-                    queue.set(interaction.guild.id, queueContruct);
-                    queueContruct.songs.push(song);
-                    try {
-                        connection = await joinVoiceChannel({
-                            channelId: voiceChannel.id,
-                            guildId: voiceChannel.guild.id,
-                            adapterCreator: voiceChannel.guild.voiceAdapterCreator
-                        });
-                        queueContruct.connection = connection;
-                        play(interaction.guild, queueContruct.songs[0], interaction);
-                    } catch (err) {
-                        console.log(err);
-                        queue.delete(interaction.guild.id);
-                        return interaction.followUp(err);
-                    }
-                } else {
-                    serverQueue.songs.push(song);
-                    songs.push(song.title);
-                }
-                if (musiclist.length == 0) return interaction.followUp(`${song.title} has been added to the queue!`);
-                interaction.followUp(`We are now adding ${musiclist.length} songs to the queue.\nPleas wait a moment...\nIt may take a while to add songs to the queue.`);
-
-                let token = Math.random().toString(36).slice(-8);
-
-                Index[token] = 0;
-                active[token] = 0;
-                count[token] = 0;
-                temp[token] = [];
-                allcount[token] = musiclist.length;
-                fallcount[token] = 0;
-                let next = [musiclist.shift(), Index[token], token];
-
-                let followUped = false;
-
-                const online_handler = (worker) => {
-                    if (musiclist.length <= 0) return;
-                    if (musicInfoCache.has(musiclist[0])) {
-                        song = musicInfoCache.get(musiclist.shift())
-                        temp[token].push({ song: song, index: Index[token] });
-                        Index[token]++;
-                        count[token]++;
-                        return online_handler(worker);
-                    }
-                    worker.send(next);
-                    active[token]++;
-                    Index[token]++;
-                    next = [musiclist.shift(), Index[token], token];
-                }
-                const message_handler = async (worker, message) => {
-                    if (message.type == "end") {
-                        if (message.token != token) return;
-                        temp[message.token].push({ song: message.song, index: message.index });
-                        if (cacheEnabled) musicInfoCache.set(message.song.url, message.song);
-                        count[message.token]++;
-
-                        if (musiclist.length <= 0) {
-                            active[message.token]--;
-                            if (active[message.token] != 0 || allcount[message.token] == (count[message.token] + failcount[message.token])) return;
-                            followUped = true;
-                            serverQueue.songs.push(...temp[message.token].sort((a, b) => ((a.index > b.index) ? -1 : 1)).map(x => x.song));
-                            serverQueue.textChannel.send(`Added ${count[message.token]} songs to the queue!`);
-                            delete active[message.token];
-                            delete Index[message.token];
-                            delete count[message.token];
-                            delete temp[message.token];
-                            delete allcount[message.token];
-                            delete fallcount[message.token];
-                            return
-                        } else {
-                            if (musicInfoCache.has(musiclist[0])) {
-                                song = musicInfoCache.get(musiclist.shift())
-                                Index[token]++;
-                                count[token]++;
-                                return message_handler(worker, { type: "end", token: token, song: song, index: Index[token] - 1 });
-                            }
-                            worker.send(next);
-                            Index[message.token]++;
-                            next = [musiclist.shift(), Index[message.token], message.token];
-                        }
-
-                    } else if (message.type == "error") {
-                        if (musiclist.length == 0) {
-                            active[message.token]--;
-                            if (active[message.token] != 0) return;
-                            followUped = true;
-                            serverQueue.songs.push(...temp[message.token].sort((a, b) => ((a.index > b.index) ? -1 : 1)).map(x => x.song));
-                            interaction.followUp(`Added ${count[message.token]} songs to the queue!`);
-                            delete active[message.token];
-                            delete Index[message.token];
-                            delete count[message.token];
-                            delete temp[message.token];
-                            delete allcount[message.token];
-                            delete fallcount[message.token];
-                            return
-                        } else {
-                            if (musicInfoCache.has(musiclist[0])) {
-                                song = musicInfoCache.get(musiclist.shift())
-                                Index[token]++;
-                                fallcount[token]++;
-                                return message_handler(worker, { type: "end", token: token, song: song, index: Index[token] - 1 });
-                            }
-                            worker.send(next);
-                            Index[message.token]++;
-                            next = [musiclist.shift(), Index[token], token];
-                        }
-                    }
-                }
-                if (Object.keys(cluster.workers).length == 0) {
-                    for (i = 0; i < numCPUs * multiCoreScale; i++) {
-                        cluster.fork();
-                    }
-                } else {
-                    for (const worker in cluster.workers) {
-                        online_handler(cluster.workers[worker]);
-                    }
-                }
-                cluster.on('online', online_handler);
-                cluster.on('message', message_handler);
-
-                break;
-
-            case 'skip':
-                serverQueue = queue.get(interaction.guild.id);
-                if (!interaction.member.voice.channel) return interaction.followUp('You have to be in a voice channel to skip the music!');
-                if (!serverQueue) return interaction.followUp('There is no song that I could skip!');
-                serverQueue.player.stop();
-                interaction.followUp('Skipped the song!');
-                break;
-
-            case 'stop':
-                serverQueue = queue.get(interaction.guild.id);
-                if (!interaction.member.voice.channel) return interaction.followUp('You have to be in a voice channel to stop the music!');
-                if (!serverQueue) return interaction.followUp('There is no song that I could stop!');
-                serverQueue.songs = [];
-                serverQueue.autoPlay = false;
-                serverQueue.player.stop();
-                interaction.followUp('Stopped the music!');
-                break;
-
-            case 'queue':
-                serverQueue = queue.get(interaction.guild.id);
-                if (!serverQueue) return interaction.followUp('There is no song that I could tell you the queue!');
-                var songlist = serverQueue.songs.map(song => `**-** ${song.title}`).join('\n');
-                if (songlist.length > 1500) {
-                    songlist = songlist.slice(0, 1500).split('\n').slice(0, -1).join('\n') + `\n...and more ${serverQueue.songs.map(song => `**-** ${song.title}`).length - songlist.slice(0, 1500).split('\n').slice(0, -1).length} songs in queue!`;
-                }
-                embed = new EmbedBuilder()
-                    .setTitle('Queue')
-                    .setDescription(`Now Playing: ${serverQueue.songs[0].title}\n\n${songlist}`)
-                    .setFooter({
-                        text: "SakuraMusic V2",
-                        iconURL: client.user.displayAvatarURL(),
-                    }
-                    )
-                    .setColor('#ff0000')
-                interaction.followUp({ embeds: [embed] });
-                break;
-
-            case 'nowplaying':
-                serverQueue = queue.get(interaction.guild.id);
-                if (!serverQueue) return interaction.followUp('There is no song that I could tell you about the song you are playing!');
-                timestamp = Date.now();
-                playsec = Math.floor(serverQueue.resource.playbackDuration / 1000);
-
-                playtimetext = toHms(playsec);
-
-                musicplaytimetext = toHms(serverQueue.songs[0].totalsec)
-
-                function getprogress(nowsec, allsec) {
-                    oneblockamount = allsec / 20;
-                    nowblock = Math.floor(nowsec / oneblockamount);
-                    playblock = "■";
-                    noplayblock = "□";
-                    progresstext = "[" + playblock.repeat(((nowblock - 1) < 0) ? "0" : nowblock - 1) + "☆" + noplayblock.repeat(20 - nowblock) + "]";
-                    return progresstext;
-                }
-
-                nowprogresstext = getprogress(playsec, serverQueue.songs[0].totalsec);
-
-                embed = {
-                    "title": serverQueue.songs[0].title,
-                    "url": serverQueue.songs[0].url,
-                    "color": Math.floor(Math.random() * 16777214) + 1,
-                    "thumbnail": {
-                        "url": serverQueue.songs[0].thumbnail
-                    },
-                    "footer": {
-                        text: "SakuraMusic V2",
-                        iconURL: client.user.displayAvatarURL(),
-                    },
-                    "author": {
-                        "name": serverQueue.songs[0].author.name,
-                        "url": serverQueue.songs[0].author.url
-                    },
-                    "fields": [{
-                        "name": "channel",
-                        "value": serverQueue.songs[0].author.name
-                    }, {
-                        "name": "Play time",
-                        "value": playtimetext,
-                        "inline": true
-                    }, {
-                        "name": "Music length",
-                        "value": musicplaytimetext,
-                        "inline": true
-                    }, {
-                        "name": "Progress",
-                        "value": nowprogresstext
-                    }, {
-                        "name": "viewCount",
-                        "value": serverQueue.songs[0].viewcount,
-                        "inline": true
-                    }, {
-                        "name": "Channel:subscriber",
-                        "value": serverQueue.songs[0].author.subscriber_count,
-                        "inline": true
-                    }, {
-                        "name": "Channel:verified",
-                        "value": serverQueue.songs[0].author.verified,
-                        "inline": true
-                    }]
-                };
-
-                interaction.followUp({ embeds: [embed] });
-                break;
-
-            case 'loop':
-                serverQueue = queue.get(interaction.guild.id);
-                if (!serverQueue) return interaction.followUp('There is no song that I could set up loop mode!');
-                if (serverQueue.loop === false) {
-                    serverQueue.loop = true;
-                    interaction.followUp('Looping the queue!');
-                } else {
-                    serverQueue.loop = false;
-                    interaction.followUp('Stopped looping the queue!');
-                }
-                break;
-
-            case 'queueloop':
-                serverQueue = queue.get(interaction.guild.id);
-                if (!serverQueue) return interaction.followUp('There is no song that I could set up queue loop mode!');
-                if (serverQueue.queueloop === false) {
-                    serverQueue.queueloop = true;
-                    interaction.followUp('Looping the queue!');
-                } else {
-                    serverQueue.queueloop = false;
-                    interaction.followUp('Stopped looping the queue!');
-                }
-                break;
-
-            case 'volume':
-                serverQueue = queue.get(interaction.guild.id);
-                if (!serverQueue) return interaction.followUp('There is no song that I could change volume!');
-                if (!interaction.options.getString('volume')) return interaction.followUp(`The current volume is: **${serverQueue.volume}**`);
-                if (interaction.options.getString('volume') > 10 || interaction.options.getString('volume') < 1) return interaction.followUp('Please enter a number between 1 and 10!');
-                serverQueue.resource.volume.setVolume(interaction.options.getString('volume') / 10);
-                interaction.followUp(`I set the volume to: **${interaction.options.getString('volume')}**`);
-                break;
-
-            case 'pause':
-                serverQueue = queue.get(interaction.guild.id);
-                if (!serverQueue) return interaction.followUp('There is no song that I could pause!');
-                if (serverQueue.paused) return interaction.followUp('The song is already paused!');
-                serverQueue.paused = true;
-                serverQueue.player.pause();
-                interaction.followUp('Paused the song!');
-                break;
-
-            case 'resume':
-                serverQueue = queue.get(interaction.guild.id);
-                if (!serverQueue) return interaction.followUp('There is no song that I could resume!');
-                if (!serverQueue.paused) return interaction.followUp('The song is already playing!');
-                serverQueue.paused = false;
-                serverQueue.player.unpause();
-                interaction.followUp('Resumed the song!');
-                break;
-
-            case 'remove':
-                serverQueue = queue.get(interaction.guild.id);
-                if (!serverQueue) return interaction.followUp('There is no song that I could remove!');
-                if (!interaction.options.getString('songnumber')) return interaction.followUp('Please enter a song number!');
-                if (interaction.options.getString('songnumber') > serverQueue.songs.length || interaction.options.getString('songnumber') < 1) return interaction.followUp('Please enter a valid song number!');
-                serverQueue.songs.splice(interaction.options.getString('songnumber') - 1, 1);
-                interaction.followUp(`I removed the song number: **${interaction.options.getString('songnumber')}**`);
-                break;
-
-            case 'shuffle':
-                serverQueue = queue.get(interaction.guild.id);
-                if (!serverQueue) return interaction.followUp('There is no song that I could shuffle!');
-                if (serverQueue.songs.length < 3) return interaction.followUp('There must be at least 3 songs in the queue to shuffle it!');
-                for (let i = serverQueue.songs.length - 1; i > 1; i--) {
-                    const j = 1 + Math.floor(Math.random() * i);
-                    [serverQueue.songs[i], serverQueue.songs[j]] = [serverQueue.songs[j], serverQueue.songs[i]];
-                }
-                interaction.followUp('Shuffled the queue!');
-                break;
-
-            case 'skipto':
-                serverQueue = queue.get(interaction.guild.id);
-                if (!serverQueue) return interaction.followUp('There is no song that I could skip to!');
-                if (!interaction.options.getString('songnumber')) return interaction.followUp('Please enter a song number!');
-                if (interaction.options.getString('songnumber') > serverQueue.songs.length || interaction.options.getString('songnumber') < 1) return interaction.followUp('Please enter a valid song number!');
-                removed = serverQueue.songs.splice(0, interaction.options.getString('songnumber') - 1);
-                if (serverQueue.queueloop === true) serverQueue.push(removed);
-                serverQueue.player.stop();
-                interaction.followUp(`I skipped to the song number: **${interaction.options.getString('songnumber')}**`);
-                break;
-
-            case 'help':
-                embed = new EmbedBuilder()
-                    .setTitle('Help')
-                    .setDescription('**play** - Plays a song\n**skip** - Skips a song\n**stop** - Stops the music\n**queue** - Shows the queue\n**nowplaying** - Shows the song that is playing\n**loop** - Loops the queue\n**queueloop** - Loops the queue\n**volume** - Changes the volume\n**pause** - Pauses the song\n**resume** - Resumes the song\n**remove** - Removes a song from the queue\n**shuffle** - Shuffles the queue\n**skipto** - Skips to a song in the queue\n**help** - Shows this message\n**ping** - Shows the ping\n**invite** - Invite SakuraMusic v2 to your server\n**autoplay** - Autoplay the music if the queue is empty')
-                    .setFooter({
-                        text: "SakuraMusic v2",
-                        iconURL: client.user.displayAvatarURL(),
-                    })
-                    .setColor('#ff0000')
-                interaction.followUp({ embeds: [embed] });
-                break;
-
-            case 'ping':
-                embed = new EmbedBuilder()
-                    .setTitle('Pong!')
-                    .setDescription(`Latency: **${Date.now() - interaction.createdTimestamp}ms**\nAPI Latency: **${Math.round(client.ws.ping)}ms**`)
-                    .setFooter({
-                        text: "SakuraMusic v2",
-                        iconURL: client.user.displayAvatarURL(),
-                    })
-                    .setColor('#ff0000')
-                interaction.followUp({ embeds: [embed] });
-                break;
-
-            case 'clear':
-                serverQueue = queue.get(interaction.guild.id);
-                if (!serverQueue) return interaction.followUp('There is no song that I could clear!');
-                serverQueue.songs = [];
-                serverQueue.player.stop();
-                interaction.followUp('Cleared the queue!');
-                break;
-
-            case 'invite':
-                embed = new EmbedBuilder()
-                    .setTitle('Invite')
-                    .setDescription(`[Click here to invite SakuraMusic v2](https://discord.com/api/oauth2/authorize?client_id=${client.user.id}&permissions=8&scope=bot%20applications.commands)`)
-                    .setFooter({
-                        text: "SakuraMusic v2",
-                        iconURL: client.user.displayAvatarURL(),
-                    })
-                    .setColor('#ff0000')
-                interaction.followUp({ embeds: [embed] });
-                break;
-
-            case 'autoplay':
-                if (!interaction.member.voice.channel) return interaction.followUp('You have to be in a voice channel to enable/disable autoplay!');
-                serverQueue = queue.get(interaction.guild.id);
-                if (!serverQueue) return interaction.followUp('Play a song first!');
-                if (serverQueue.autoPlay === false) {
-                    serverQueue.autoPlay = true;
-                    interaction.followUp('Autoplay is enabled!');
-                } else {
-                    serverQueue.autoPlay = false;
-                    interaction.followUp('Autoplay is disabled!');
-                }
+        const command = commands.get(interaction.commandName);
+        if (!command) return;
+        try {
+            await command.execute(interaction, context);
+        } catch (error) {
+            console.error(error);
+            interaction.followUp('There was an error executing that command!');
         }
     });
 
@@ -877,19 +307,19 @@ if (cluster.isPrimary) {
                         }
                     });
                     if (songInfo) {
-                        song = {
-                            title: songInfo.videoDetails.title,
-                            url: songInfo.videoDetails.video_url,
-                            totalsec: songInfo.videoDetails.lengthSeconds,
-                            viewcount: songInfo.videoDetails.viewCount,
-                            author: {
-                                name: songInfo.videoDetails.author.name,
-                                url: songInfo.videoDetails.author.channel_url,
-                                subscriber_count: songInfo.videoDetails.author.subscriber_count,
-                                verified: songInfo.videoDetails.author.verified
-                            },
-                            thumbnail: songInfo.videoDetails.thumbnails[Object.keys(songInfo.videoDetails.thumbnails).length - 1].url
-                        };
+                        song = new Song({
+            title: songInfo.videoDetails.title,
+            url: songInfo.videoDetails.video_url,
+            totalsec: songInfo.videoDetails.lengthSeconds,
+            viewcount: songInfo.videoDetails.viewCount,
+            author: {
+                name: songInfo.videoDetails.author.name,
+                url: songInfo.videoDetails.author.channel_url,
+                subscriber_count: songInfo.videoDetails.author.subscriber_count,
+                verified: songInfo.videoDetails.author.verified
+            },
+            thumbnail: songInfo.videoDetails.thumbnails[Object.keys(songInfo.videoDetails.thumbnails).length - 1].url
+        });
                         serverQueue.songs.push(song);
                         serverQueue.autoPlayPosition++;
                         return play(guild, serverQueue.songs[0], interaction);
@@ -905,34 +335,33 @@ if (cluster.isPrimary) {
             return;
         }
 
-        //let stream_playdl = await playdl.stream(song.url)
-        //ytdl-core
-        let stream_ytdl = ytdl(song.url, {
-            filter: 'audioonly',
-            quality: 'highestaudio',
-            highWaterMark: 1 << 25
-        });
-        
-        /*
-        let stream_ytdlp = new streamer('./' + yt_dlp_filename).execStream([
-            song.url,
-            '-f',
-            'best[ext=webm+acodec=opus+asr=48000]/best[ext=mp4]/best',
-        ]);
-        */
-        
+        if (song.type === 'attachment' && song.expiresAt && Date.now() > song.expiresAt) {
+            serverQueue.textChannel.send('Attachment link expired, skipping.');
+            serverQueue.songs.shift();
+            return play(guild, serverQueue.songs[0], interaction);
+        }
 
-        
-
-        
+        let stream_ytdl;
         player = createAudioPlayer({
             behaviors: {
                 noSubscriber: NoSubscriberBehavior.Stop,
             },
         });
-        
 
-        resource = createAudioResource(stream_ytdl, { inlineVolume: true, inputType: stream.type });
+        if (song.type === 'attachment') {
+            const streamAttachment = await new Promise((resolve, reject) => {
+                https.get(song.url, res => resolve(res)).on('error', reject);
+            });
+            resource = createAudioResource(streamAttachment, { inlineVolume: true });
+        } else {
+            stream_ytdl = ytdl(song.url, {
+                filter: 'audioonly',
+                quality: 'highestaudio',
+                highWaterMark: 1 << 25
+            });
+            resource = createAudioResource(stream_ytdl, { inlineVolume: true, inputType: stream.type });
+        }
+
         resource.volume.setVolume(0.2);
         await player.play(resource);
         serverQueue.player = player;
@@ -946,6 +375,7 @@ if (cluster.isPrimary) {
                     serverQueue.songs.push(serverQueue.songs[0]);
                 }
                 songcache = serverQueue.songs.shift();
+                if (songcache) serverQueue.history.push(songcache);
             }
 
             play(guild, serverQueue.songs[0], interaction, songcache);
@@ -992,6 +422,8 @@ if (cluster.isPrimary) {
         serverQueue.starttimestamp = Date.now();
     }
 
+    context.play = play;
+
     function pickNextSong(array, playedsong) {
         if (array.length == 0 || array.length == 1) return null;
         array = array[Math.floor(Math.random() * array.length)]
@@ -1034,31 +466,6 @@ if (cluster.isPrimary) {
         }
     });
 
-    function toHms(t) {
-        hms = "";
-        h = t / 3600 | 0;
-        m = t % 3600 / 60 | 0;
-        s = t % 60;
-
-        if (h != 0) {
-            hms = h + ":" + padZero(m) + ":" + padZero(s);
-        } else if (m != 0) {
-            hms = m + ":" + padZero(s);
-        } else {
-            hms = "0:" + padZero(s);
-        }
-
-        return hms;
-
-        function padZero(v) {
-            if (v < 10) {
-                return "0" + v;
-            } else {
-                return v;
-            }
-        }
-    }
-
     function getQueueData() {
         let data = [];
         var i = 0;
@@ -1083,32 +490,3 @@ if (cluster.isPrimary) {
 
 
     client.login(token);
-
-} else {
-    process.on('message', async (message) => {
-        if (message[0] === "stop") return process.exit(0);
-        songInfo = await ytdl.getInfo(message[0]).catch(error => {
-            process.send({ type: "error", value: [error], index: message[1], token: message[2] });
-
-        });
-
-        if (!songInfo) return process.send({ type: "error", value: ["No song found"], index: message[1], token: message[2] });
-
-        song = {
-            title: songInfo.videoDetails.title,
-            url: songInfo.videoDetails.video_url,
-            totalsec: songInfo.videoDetails.lengthSeconds,
-            viewcount: songInfo.videoDetails.viewCount,
-            author: {
-                name: songInfo.videoDetails.author.name,
-                url: songInfo.videoDetails.author.channel_url,
-                subscriber_count: songInfo.videoDetails.author.subscriber_count,
-                verified: songInfo.videoDetails.author.verified
-            },
-            thumbnail: songInfo.videoDetails.thumbnails[Object.keys(songInfo.videoDetails.thumbnails).length - 1].url
-        };
-
-        process.send({ type: "end", song: song, index: message[1], token: message[2] });
-
-    });
-}

--- a/src/Commands/Autoplay.js
+++ b/src/Commands/Autoplay.js
@@ -1,0 +1,26 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType } = require('discord.js');
+
+class Autoplay extends BaseCommand {
+    constructor() {
+        super({
+            name: 'autoplay',
+            description: 'Autoplay the music if the queue is empty',
+            type: ApplicationCommandType.ChatInput,
+        });
+    }
+
+    async execute(interaction, { queue }) {
+        if (!interaction.member.voice.channel) return interaction.followUp('You have to be in a voice channel to enable/disable autoplay!');
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!serverQueue) return interaction.followUp('Play a song first!');
+        if (serverQueue.autoPlay === false) {
+            serverQueue.autoPlay = true;
+            interaction.followUp('Autoplay is enabled!');
+        } else {
+            serverQueue.autoPlay = false;
+            interaction.followUp('Autoplay is disabled!');
+        }
+    }
+}
+module.exports = Autoplay;

--- a/src/Commands/BaseCommand.js
+++ b/src/Commands/BaseCommand.js
@@ -1,0 +1,9 @@
+class BaseCommand {
+    constructor(data) {
+        this.data = data;
+    }
+    async execute() {
+        throw new Error('execute method must be implemented');
+    }
+}
+module.exports = BaseCommand;

--- a/src/Commands/Clear.js
+++ b/src/Commands/Clear.js
@@ -1,0 +1,21 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType } = require('discord.js');
+
+class Clear extends BaseCommand {
+    constructor() {
+        super({
+            name: 'clear',
+            description: 'Clear the queue',
+            type: ApplicationCommandType.ChatInput,
+        });
+    }
+
+    async execute(interaction, { queue }) {
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!serverQueue) return interaction.followUp('There is no song that I could clear!');
+        serverQueue.songs = [];
+        serverQueue.player.stop();
+        interaction.followUp('Cleared the queue!');
+    }
+}
+module.exports = Clear;

--- a/src/Commands/Help.js
+++ b/src/Commands/Help.js
@@ -1,0 +1,25 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType, EmbedBuilder } = require('discord.js');
+
+class Help extends BaseCommand {
+    constructor() {
+        super({
+            name: 'help',
+            description: 'Show the help',
+            type: ApplicationCommandType.ChatInput,
+        });
+    }
+
+    async execute(interaction, { client }) {
+        const embed = new EmbedBuilder()
+            .setTitle('Help')
+            .setDescription('**play** - Plays a song\n**skip** - Skips a song\n**stop** - Stops the music\n**queue** - Shows the queue\n**nowplaying** - Shows the song that is playing\n**loop** - Loops the queue\n**queueloop** - Loops the queue\n**seek** - Seek to a time in the current song\n**volume** - Changes the volume\n**pause** - Pauses the song\n**resume** - Resumes the song\n**remove** - Removes a song from the queue\n**shuffle** - Shuffles the queue\n**skipto** - Skips to a song in the queue\n**help** - Shows this message\n**ping** - Shows the ping\n**invite** - Invite SakuraMusic v2 to your server\n**autoplay** - Autoplay the music if the queue is empty')
+            .setFooter({
+                text: 'SakuraMusic v2',
+                iconURL: client.user.displayAvatarURL(),
+            })
+            .setColor('#ff0000');
+        interaction.followUp({ embeds: [embed] });
+    }
+}
+module.exports = Help;

--- a/src/Commands/History.js
+++ b/src/Commands/History.js
@@ -1,0 +1,51 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType, ApplicationCommandOptionType, PermissionFlagsBits } = require('discord.js');
+
+class History extends BaseCommand {
+    constructor() {
+        super({
+            name: 'history',
+            description: 'Show playback history or replay a song',
+            type: ApplicationCommandType.ChatInput,
+            options: [
+                {
+                    name: 'index',
+                    description: 'History entry to play',
+                    type: ApplicationCommandOptionType.Integer,
+                    required: false
+                }
+            ]
+        });
+    }
+
+    async execute(interaction, context) {
+        const { queue } = context;
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!serverQueue || serverQueue.history.length === 0) {
+            return interaction.followUp('No history available.');
+        }
+
+        const idx = interaction.options.getInteger('index');
+        if (!idx) {
+            const list = serverQueue.history.map((s, i) => {
+                const expired = s.type === 'attachment' && s.expiresAt && Date.now() > s.expiresAt ? ' (expired)' : '';
+                return `${i + 1}. ${s.title}${expired}`;
+            }).join('\n');
+            return interaction.followUp(`Playback history:\n${list}`);
+        }
+
+        const song = serverQueue.history[idx - 1];
+        if (!song) return interaction.followUp('Invalid history index.');
+        if (song.type === 'attachment' && song.expiresAt && Date.now() > song.expiresAt) {
+            return interaction.followUp('This attachment link has expired and cannot be played.');
+        }
+        const voiceChannel = interaction.member.voice.channel;
+        if (!voiceChannel) return interaction.followUp('You need to be in a voice channel to play music!');
+
+        serverQueue.songs.unshift(song);
+        if (serverQueue.player) serverQueue.player.stop();
+        return interaction.followUp(`Playing ${song.title} from history.`);
+    }
+}
+
+module.exports = History;

--- a/src/Commands/Invite.js
+++ b/src/Commands/Invite.js
@@ -1,0 +1,25 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType, EmbedBuilder } = require('discord.js');
+
+class Invite extends BaseCommand {
+    constructor() {
+        super({
+            name: 'invite',
+            description: 'Invite SakuraMusicV2 to your server',
+            type: ApplicationCommandType.ChatInput,
+        });
+    }
+
+    async execute(interaction, { client }) {
+        const embed = new EmbedBuilder()
+            .setTitle('Invite')
+            .setDescription(`[Click here to invite SakuraMusic v2](https://discord.com/api/oauth2/authorize?client_id=${client.user.id}&permissions=8&scope=bot%20applications.commands)`)
+            .setFooter({
+                text: 'SakuraMusic v2',
+                iconURL: client.user.displayAvatarURL(),
+            })
+            .setColor('#ff0000');
+        interaction.followUp({ embeds: [embed] });
+    }
+}
+module.exports = Invite;

--- a/src/Commands/Loop.js
+++ b/src/Commands/Loop.js
@@ -1,0 +1,25 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType } = require('discord.js');
+
+class Loop extends BaseCommand {
+    constructor() {
+        super({
+            name: 'loop',
+            description: 'Loop the song',
+            type: ApplicationCommandType.ChatInput,
+        });
+    }
+
+    async execute(interaction, { queue }) {
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!serverQueue) return interaction.followUp('There is no song that I could set up loop mode!');
+        if (serverQueue.loop === false) {
+            serverQueue.loop = true;
+            interaction.followUp('Looping the queue!');
+        } else {
+            serverQueue.loop = false;
+            interaction.followUp('Stopped looping the queue!');
+        }
+    }
+}
+module.exports = Loop;

--- a/src/Commands/NowPlaying.js
+++ b/src/Commands/NowPlaying.js
@@ -1,0 +1,54 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType } = require('discord.js');
+const { toHms } = require('../utils');
+
+class NowPlaying extends BaseCommand {
+    constructor() {
+        super({
+            name: 'nowplaying',
+            description: 'Show the song you are playing',
+            type: ApplicationCommandType.ChatInput,
+        });
+    }
+
+    async execute(interaction, { queue, client }) {
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!serverQueue) return interaction.followUp('There is no song that I could tell you about the song you are playing!');
+        const playsec = Math.floor(serverQueue.resource.playbackDuration / 1000);
+        const playtimetext = toHms(playsec);
+        const musicplaytimetext = toHms(serverQueue.songs[0].totalsec);
+        const getprogress = (nowsec, allsec) => {
+            const oneblockamount = allsec / 20;
+            const nowblock = Math.floor(nowsec / oneblockamount);
+            const playblock = '■';
+            const noplayblock = '□';
+            return '[' + playblock.repeat(((nowblock - 1) < 0) ? 0 : nowblock - 1) + '☆' + noplayblock.repeat(20 - nowblock) + ']';
+        };
+        const nowprogresstext = getprogress(playsec, serverQueue.songs[0].totalsec);
+        const embed = {
+            title: serverQueue.songs[0].title,
+            url: serverQueue.songs[0].url,
+            color: Math.floor(Math.random() * 16777214) + 1,
+            thumbnail: { url: serverQueue.songs[0].thumbnail },
+            footer: {
+                text: 'SakuraMusic V2',
+                iconURL: client.user.displayAvatarURL(),
+            },
+            author: {
+                name: serverQueue.songs[0].author.name,
+                url: serverQueue.songs[0].author.url,
+            },
+            fields: [
+                { name: 'channel', value: serverQueue.songs[0].author.name },
+                { name: 'Play time', value: playtimetext, inline: true },
+                { name: 'Music length', value: musicplaytimetext, inline: true },
+                { name: 'Progress', value: nowprogresstext },
+                { name: 'viewCount', value: serverQueue.songs[0].viewcount, inline: true },
+                { name: 'Channel:subscriber', value: serverQueue.songs[0].author.subscriber_count, inline: true },
+                { name: 'Channel:verified', value: serverQueue.songs[0].author.verified, inline: true },
+            ],
+        };
+        interaction.followUp({ embeds: [embed] });
+    }
+}
+module.exports = NowPlaying;

--- a/src/Commands/Pause.js
+++ b/src/Commands/Pause.js
@@ -1,0 +1,21 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType } = require('discord.js');
+
+class Pause extends BaseCommand {
+    constructor() {
+        super({
+            name: 'pause',
+            description: 'Pause the music',
+            type: ApplicationCommandType.ChatInput,
+        });
+    }
+
+    async execute(interaction, { queue }) {
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!serverQueue) return interaction.followUp('There is no song that I could pause!');
+        if (serverQueue.paused) return interaction.followUp('The song is already paused!');
+        serverQueue.pause();
+        interaction.followUp('Paused the song!');
+    }
+}
+module.exports = Pause;

--- a/src/Commands/Ping.js
+++ b/src/Commands/Ping.js
@@ -1,0 +1,25 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType, EmbedBuilder } = require('discord.js');
+
+class Ping extends BaseCommand {
+    constructor() {
+        super({
+            name: 'ping',
+            description: 'Show the ping',
+            type: ApplicationCommandType.ChatInput,
+        });
+    }
+
+    async execute(interaction, { client }) {
+        const embed = new EmbedBuilder()
+            .setTitle('Pong!')
+            .setDescription(`Latency: **${Date.now() - interaction.createdTimestamp}ms**\nAPI Latency: **${Math.round(client.ws.ping)}ms**`)
+            .setFooter({
+                text: 'SakuraMusic v2',
+                iconURL: client.user.displayAvatarURL(),
+            })
+            .setColor('#ff0000');
+        interaction.followUp({ embeds: [embed] });
+    }
+}
+module.exports = Ping;

--- a/src/Commands/Play.js
+++ b/src/Commands/Play.js
@@ -1,0 +1,213 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType, ApplicationCommandOptionType, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const { joinVoiceChannel } = require('@discordjs/voice');
+const ytpl = require('ytpl');
+const playdl = require('play-dl');
+const ytdl = require('ytdl-core');
+
+class Play extends BaseCommand {
+    constructor() {
+        super({
+            name: 'play',
+            description: 'Play music from Youtube or attachment',
+            type: ApplicationCommandType.ChatInput,
+            options: [
+                {
+                    name: 'video_info',
+                    description: 'Youtube URL or Search Query',
+                    type: ApplicationCommandOptionType.String,
+                    required: false
+                },
+                {
+                    name: 'file',
+                    description: 'Audio file attachment',
+                    type: ApplicationCommandOptionType.Attachment,
+                    required: false
+                }
+            ]
+        });
+    }
+
+    async execute(interaction, context) {
+        const { queue, MusicQueue, Song, musicInfoCache, cacheEnabled } = context;
+
+        const voiceChannel = interaction.member.voice.channel;
+        if (!voiceChannel) return interaction.followUp('You need to be in a voice channel to play music!');
+
+        const permissions = voiceChannel.permissionsFor(interaction.client.user);
+        if (!permissions.has(PermissionFlagsBits.Connect) || !permissions.has(PermissionFlagsBits.Speak)) {
+            return interaction.followUp("I need the permissions to join and speak in your voice channel!");
+        }
+
+        let serverQueue = queue.get(interaction.guild.id);
+        let url = interaction.options.getString('video_info');
+        const attachment = interaction.options.getAttachment('file');
+        if (!url && !attachment) {
+            return interaction.followUp('You need to provide a URL/search query or attach an audio file.');
+        }
+
+        if (attachment) {
+            const song = new Song({
+                title: attachment.name,
+                url: attachment.url,
+                totalsec: 0,
+                viewcount: 0,
+                author: { name: interaction.user.username, url: null },
+                thumbnail: interaction.user.displayAvatarURL(),
+                type: 'attachment',
+                expiresAt: Date.now() + 7200000
+            });
+
+            if (!serverQueue) {
+                const queueContruct = new MusicQueue(interaction.channel, voiceChannel);
+                queue.set(interaction.guild.id, queueContruct);
+                queueContruct.songs.push(song);
+                try {
+                    const connection = await joinVoiceChannel({
+                        channelId: voiceChannel.id,
+                        guildId: voiceChannel.guild.id,
+                        adapterCreator: voiceChannel.guild.voiceAdapterCreator
+                    });
+                    queueContruct.connection = connection;
+                    context.play(interaction.guild, queueContruct.songs[0], interaction);
+                } catch (err) {
+                    console.log(err);
+                    queue.delete(interaction.guild.id);
+                    return interaction.followUp(err);
+                }
+            } else {
+                serverQueue.songs.push(song);
+            }
+            return interaction.followUp(`${song.title} has been added to the queue!`);
+        }
+
+        const musiclist = [];
+        let totalTracks = 1;
+        if (url.includes('list=') && !url.includes('watch?v=')) {
+            const playlist = await ytpl(url, { limit: Infinity }).catch(error => {
+                console.log(error);
+                interaction.followUp("Oops, there seems to have been an error.\nPlease check the following points.\n*Is the URL correct?\n*Are you using a Youtube URL?\n*Is the URL shortened? \nIf the problem still persists, please wait a while and try again.");
+            });
+            if (!playlist) return;
+            musiclist.push(...playlist.items.map(x => x.url.substring(0, x.url.indexOf("&list="))));
+            totalTracks = playlist.items.length;
+        } else {
+            let errorFLG = false;
+            if (!url.includes('youtube.com') && !url.includes('youtu.be/')) {
+                const yt_info = await playdl.search(url, { limit: 1 }).catch(async error => {
+                    errorFLG = true;
+                    return interaction.followUp("Oops, there seems to have been an error.\nPlease check the following points.\n*Is the URL correct?\n*Are you using a URL other than Youtube?\n*Is the URL shortened? \nIf the problem still persists, please wait a while and try again.");
+                });
+                if (errorFLG) return;
+                if (yt_info.length == 0) return interaction.followUp("Oops, there seems to have been an error.\nPlease check the following points.\n*Is the URL correct?\n*Are you using a URL other than Youtube?\n*Is the URL shortened? \nIf the problem still persists, please wait a while and try again.");
+                url = yt_info[0].url;
+            }
+            musiclist.push(url);
+        }
+
+        let song;
+        if (!musicInfoCache.has(musiclist[0])) {
+            const songInfo = await ytdl.getInfo(musiclist.shift()).catch(async error => {});
+            if (!songInfo) {
+                return interaction.followUp("Oops, there seems to have been an error.\nPlease check the following points.\n*Is the URL correct?\n*Are you using a URL other than Youtube?\n*Is the URL shortened? \nIf the problem still persists, please wait a while and try again.");
+            }
+            song = new Song({
+                title: songInfo.videoDetails.title,
+                url: songInfo.videoDetails.video_url,
+                totalsec: songInfo.videoDetails.lengthSeconds,
+                viewcount: songInfo.videoDetails.viewCount,
+                author: {
+                    name: songInfo.videoDetails.author.name,
+                    url: songInfo.videoDetails.author.channel_url,
+                    subscriber_count: songInfo.videoDetails.author.subscriber_count,
+                    verified: songInfo.videoDetails.author.verified
+                },
+                thumbnail: songInfo.videoDetails.thumbnails[Object.keys(songInfo.videoDetails.thumbnails).length - 1].url
+            });
+            if (cacheEnabled) musicInfoCache.set(songInfo.videoDetails.video_url, song);
+        } else {
+            song = musicInfoCache.get(musiclist.shift());
+        }
+
+        if (!serverQueue) {
+            const queueContruct = new MusicQueue(interaction.channel, voiceChannel);
+            queue.set(interaction.guild.id, queueContruct);
+            queueContruct.songs.push(song);
+            try {
+                const connection = await joinVoiceChannel({
+                    channelId: voiceChannel.id,
+                    guildId: voiceChannel.guild.id,
+                    adapterCreator: voiceChannel.guild.voiceAdapterCreator
+                });
+                queueContruct.connection = connection;
+                context.play(interaction.guild, queueContruct.songs[0], interaction);
+            } catch (err) {
+                console.log(err);
+                queue.delete(interaction.guild.id);
+                return interaction.followUp(err);
+            }
+        } else {
+            serverQueue.songs.push(song);
+        }
+
+        if (musiclist.length === 0) return interaction.followUp(`${song.title} has been added to the queue!`);
+        interaction.followUp(`We are now adding ${musiclist.length} songs to the queue.\nPleas wait a moment...\nIt may take a while to add songs to the queue.`);
+
+        const remaining = musiclist.length;
+        const total = totalTracks;
+
+        setImmediate(async () => {
+            let processed = 1;
+            const progressEmbeds = [];
+            const batchEmbeds = [];
+            const batchLimit = total < 300 ? Infinity : total < 1000 ? 5 : 10;
+
+            for (const url of musiclist) {
+                let info;
+                if (musicInfoCache.has(url)) {
+                    info = musicInfoCache.get(url);
+                } else {
+                    const songInfo = await ytdl.getInfo(url).catch(() => null);
+                    if (songInfo) {
+                        info = new Song({
+                            title: songInfo.videoDetails.title,
+                            url: songInfo.videoDetails.video_url,
+                            totalsec: songInfo.videoDetails.lengthSeconds,
+                            viewcount: songInfo.videoDetails.viewCount,
+                            author: {
+                                name: songInfo.videoDetails.author.name,
+                                url: songInfo.videoDetails.author.channel_url,
+                                subscriber_count: songInfo.videoDetails.author.subscriber_count,
+                                verified: songInfo.videoDetails.author.verified
+                            },
+                            thumbnail: songInfo.videoDetails.thumbnails[Object.keys(songInfo.videoDetails.thumbnails).length - 1].url
+                        });
+                        if (cacheEnabled) musicInfoCache.set(info.url, info);
+                    }
+                }
+                if (info) serverQueue.songs.push(info);
+                processed++;
+                if (processed % 100 === 0 || processed === total) {
+                    const embed = new EmbedBuilder().setDescription(`Adding playlist... (${processed}/${total})`);
+                    progressEmbeds.push(embed);
+                    batchEmbeds.push(embed);
+                    if (total >= 300 && (batchEmbeds.length === batchLimit || processed === total)) {
+                        await interaction.channel.send({ embeds: batchEmbeds });
+                        batchEmbeds.length = 0;
+                    }
+                }
+                await new Promise(r => setImmediate(r));
+            }
+
+            if (total < 300 && progressEmbeds.length) {
+                await interaction.channel.send({ embeds: progressEmbeds });
+            } else if (batchEmbeds.length) {
+                await interaction.channel.send({ embeds: batchEmbeds });
+            }
+
+            interaction.channel.send(`Added ${remaining} songs to the queue!`);
+        });
+    }
+}
+
+module.exports = Play;

--- a/src/Commands/Queue.js
+++ b/src/Commands/Queue.js
@@ -1,0 +1,31 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType, EmbedBuilder } = require('discord.js');
+
+class Queue extends BaseCommand {
+    constructor() {
+        super({
+            name: 'queue',
+            description: 'Show the queue',
+            type: ApplicationCommandType.ChatInput,
+        });
+    }
+
+    async execute(interaction, { queue, client }) {
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!serverQueue) return interaction.followUp('There is no song that I could tell you the queue!');
+        let songlist = serverQueue.songs.map(song => `**-** ${song.title}`).join('\n');
+        if (songlist.length > 1500) {
+            songlist = songlist.slice(0, 1500).split('\n').slice(0, -1).join('\n') + `\n...and more ${serverQueue.songs.map(song => `**-** ${song.title}`).length - songlist.slice(0, 1500).split('\n').slice(0, -1).length} songs in queue!`;
+        }
+        const embed = new EmbedBuilder()
+            .setTitle('Queue')
+            .setDescription(`Now Playing: ${serverQueue.songs[0].title}\n\n${songlist}`)
+            .setFooter({
+                text: 'SakuraMusic V2',
+                iconURL: client.user.displayAvatarURL(),
+            })
+            .setColor('#ff0000');
+        interaction.followUp({ embeds: [embed] });
+    }
+}
+module.exports = Queue;

--- a/src/Commands/QueueLoop.js
+++ b/src/Commands/QueueLoop.js
@@ -1,0 +1,25 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType } = require('discord.js');
+
+class QueueLoop extends BaseCommand {
+    constructor() {
+        super({
+            name: 'queueloop',
+            description: 'Loop the queue',
+            type: ApplicationCommandType.ChatInput,
+        });
+    }
+
+    async execute(interaction, { queue }) {
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!serverQueue) return interaction.followUp('There is no song that I could set up queue loop mode!');
+        if (serverQueue.queueloop === false) {
+            serverQueue.queueloop = true;
+            interaction.followUp('Looping the queue!');
+        } else {
+            serverQueue.queueloop = false;
+            interaction.followUp('Stopped looping the queue!');
+        }
+    }
+}
+module.exports = QueueLoop;

--- a/src/Commands/Remove.js
+++ b/src/Commands/Remove.js
@@ -1,0 +1,30 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType, ApplicationCommandOptionType } = require('discord.js');
+
+class Remove extends BaseCommand {
+    constructor() {
+        super({
+            name: 'remove',
+            description: 'Remove the song from the queue',
+            type: ApplicationCommandType.ChatInput,
+            options: [
+                {
+                    name: 'songnumber',
+                    description: 'Index',
+                    type: ApplicationCommandOptionType.String,
+                    required: true,
+                },
+            ],
+        });
+    }
+
+    async execute(interaction, { queue }) {
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!serverQueue) return interaction.followUp('There is no song that I could remove!');
+        if (!interaction.options.getString('songnumber')) return interaction.followUp('Please enter a song number!');
+        if (interaction.options.getString('songnumber') > serverQueue.songs.length || interaction.options.getString('songnumber') < 1) return interaction.followUp('Please enter a valid song number!');
+        serverQueue.songs.splice(interaction.options.getString('songnumber') - 1, 1);
+        interaction.followUp(`I removed the song number: **${interaction.options.getString('songnumber')}**`);
+    }
+}
+module.exports = Remove;

--- a/src/Commands/Resume.js
+++ b/src/Commands/Resume.js
@@ -1,0 +1,21 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType } = require('discord.js');
+
+class Resume extends BaseCommand {
+    constructor() {
+        super({
+            name: 'resume',
+            description: 'Resume the music',
+            type: ApplicationCommandType.ChatInput,
+        });
+    }
+
+    async execute(interaction, { queue }) {
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!serverQueue) return interaction.followUp('There is no song that I could resume!');
+        if (!serverQueue.paused) return interaction.followUp('The song is already playing!');
+        serverQueue.resume();
+        interaction.followUp('Resumed the song!');
+    }
+}
+module.exports = Resume;

--- a/src/Commands/Seek.js
+++ b/src/Commands/Seek.js
@@ -1,0 +1,33 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType, ApplicationCommandOptionType } = require('discord.js');
+const { parseTime, toHms } = require('../utils');
+
+class Seek extends BaseCommand {
+    constructor() {
+        super({
+            name: 'seek',
+            description: 'Seek to the given time in the current song',
+            type: ApplicationCommandType.ChatInput,
+            options: [
+                {
+                    name: 'position',
+                    description: 'Time (seconds or mm:ss)',
+                    type: ApplicationCommandOptionType.String,
+                    required: true,
+                },
+            ],
+        });
+    }
+
+    async execute(interaction, { queue }) {
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!serverQueue) return interaction.followUp('There is no song that I could seek!');
+        const position = interaction.options.getString('position');
+        const seconds = parseTime(position);
+        if (seconds === null) return interaction.followUp('Please enter a valid time!');
+        if (seconds < 0 || seconds > serverQueue.songs[0].totalsec) return interaction.followUp('Please enter a time within the length of the song!');
+        await serverQueue.seek(seconds);
+        interaction.followUp(`Seeked to **${toHms(seconds)}**!`);
+    }
+}
+module.exports = Seek;

--- a/src/Commands/Shuffle.js
+++ b/src/Commands/Shuffle.js
@@ -1,0 +1,24 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType } = require('discord.js');
+
+class Shuffle extends BaseCommand {
+    constructor() {
+        super({
+            name: 'shuffle',
+            description: 'Shuffle the queue',
+            type: ApplicationCommandType.ChatInput,
+        });
+    }
+
+    async execute(interaction, { queue }) {
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!serverQueue) return interaction.followUp('There is no song that I could shuffle!');
+        if (serverQueue.songs.length < 3) return interaction.followUp('There must be at least 3 songs in the queue to shuffle it!');
+        for (let i = serverQueue.songs.length - 1; i > 1; i--) {
+            const j = 1 + Math.floor(Math.random() * i);
+            [serverQueue.songs[i], serverQueue.songs[j]] = [serverQueue.songs[j], serverQueue.songs[i]];
+        }
+        interaction.followUp('Shuffled the queue!');
+    }
+}
+module.exports = Shuffle;

--- a/src/Commands/Skip.js
+++ b/src/Commands/Skip.js
@@ -1,0 +1,21 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType } = require('discord.js');
+
+class Skip extends BaseCommand {
+    constructor() {
+        super({
+            name: 'skip',
+            description: 'Skip the music',
+            type: ApplicationCommandType.ChatInput,
+        });
+    }
+
+    async execute(interaction, { queue }) {
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!interaction.member.voice.channel) return interaction.followUp('You have to be in a voice channel to skip the music!');
+        if (!serverQueue) return interaction.followUp('There is no song that I could skip!');
+        serverQueue.player.stop();
+        interaction.followUp('Skipped the song!');
+    }
+}
+module.exports = Skip;

--- a/src/Commands/SkipTo.js
+++ b/src/Commands/SkipTo.js
@@ -1,0 +1,32 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType, ApplicationCommandOptionType } = require('discord.js');
+
+class SkipTo extends BaseCommand {
+    constructor() {
+        super({
+            name: 'skipto',
+            description: 'Skip to the song',
+            type: ApplicationCommandType.ChatInput,
+            options: [
+                {
+                    name: 'songnumber',
+                    description: 'Index',
+                    type: ApplicationCommandOptionType.String,
+                    required: true,
+                },
+            ],
+        });
+    }
+
+    async execute(interaction, { queue }) {
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!serverQueue) return interaction.followUp('There is no song that I could skip to!');
+        if (!interaction.options.getString('songnumber')) return interaction.followUp('Please enter a song number!');
+        if (interaction.options.getString('songnumber') > serverQueue.songs.length || interaction.options.getString('songnumber') < 1) return interaction.followUp('Please enter a valid song number!');
+        const removed = serverQueue.songs.splice(0, interaction.options.getString('songnumber') - 1);
+        if (serverQueue.queueloop === true) serverQueue.push(removed);
+        serverQueue.player.stop();
+        interaction.followUp(`I skipped to the song number: **${interaction.options.getString('songnumber')}**`);
+    }
+}
+module.exports = SkipTo;

--- a/src/Commands/Stop.js
+++ b/src/Commands/Stop.js
@@ -1,0 +1,23 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType } = require('discord.js');
+
+class Stop extends BaseCommand {
+    constructor() {
+        super({
+            name: 'stop',
+            description: 'Stop the music',
+            type: ApplicationCommandType.ChatInput,
+        });
+    }
+
+    async execute(interaction, { queue }) {
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!interaction.member.voice.channel) return interaction.followUp('You have to be in a voice channel to stop the music!');
+        if (!serverQueue) return interaction.followUp('There is no song that I could stop!');
+        serverQueue.songs = [];
+        serverQueue.autoPlay = false;
+        serverQueue.player.stop();
+        interaction.followUp('Stopped the music!');
+    }
+}
+module.exports = Stop;

--- a/src/Commands/Volume.js
+++ b/src/Commands/Volume.js
@@ -1,0 +1,31 @@
+const BaseCommand = require('./BaseCommand');
+const { ApplicationCommandType, ApplicationCommandOptionType } = require('discord.js');
+
+class Volume extends BaseCommand {
+    constructor() {
+        super({
+            name: 'volume',
+            description: 'Change the volume',
+            type: ApplicationCommandType.ChatInput,
+            options: [
+                {
+                    name: 'volume',
+                    description: 'Volume',
+                    type: ApplicationCommandOptionType.String,
+                    required: true,
+                },
+            ],
+        });
+    }
+
+    async execute(interaction, { queue }) {
+        const serverQueue = queue.get(interaction.guild.id);
+        if (!serverQueue) return interaction.followUp('There is no song that I could change volume!');
+        if (!interaction.options.getString('volume')) return interaction.followUp(`The current volume is: **${Math.round(serverQueue.resource.volume.volume * 10)}**`);
+        const volume = parseInt(interaction.options.getString('volume'));
+        if (volume > 10 || volume < 1) return interaction.followUp('Please enter a number between 1 and 10!');
+        serverQueue.setVolume(volume / 10);
+        interaction.followUp(`I set the volume to: **${volume}**`);
+    }
+}
+module.exports = Volume;

--- a/src/MusicQueue.js
+++ b/src/MusicQueue.js
@@ -1,0 +1,79 @@
+const ytdl = require('ytdl-core');
+const { createAudioResource } = require('@discordjs/voice');
+
+class MusicQueue {
+  constructor(textChannel, voiceChannel) {
+    this.textChannel = textChannel;
+    this.voiceChannel = voiceChannel;
+    this.connection = null;
+    this.songs = [];
+    this.history = [];
+    this.playing = true;
+    this.loop = false;
+    this.queueloop = false;
+    this.starttimestamp = 0;
+    this.player = null;
+    this.resource = null;
+    this.paused = false;
+    this.autoPlay = false;
+    this.autoPlayPosition = 1;
+  }
+
+  addSong(song) {
+    this.songs.push(song);
+  }
+
+  skip() {
+    if (this.player) {
+      this.player.stop();
+    }
+  }
+
+  stop() {
+    this.songs = [];
+    this.autoPlay = false;
+    if (this.player) {
+      this.player.stop();
+    }
+  }
+
+  pause() {
+    if (this.player && !this.paused) {
+      this.player.pause();
+      this.paused = true;
+    }
+  }
+
+  resume() {
+    if (this.player && this.paused) {
+      this.player.unpause();
+      this.paused = false;
+    }
+  }
+
+  setVolume(volume) {
+    if (this.resource && this.resource.volume) {
+      this.resource.volume.setVolume(volume);
+    }
+  }
+
+  async seek(seconds) {
+    if (!this.player || this.songs.length === 0) return;
+    this.player.stop();
+    const stream = ytdl(this.songs[0].url, {
+      filter: 'audioonly',
+      quality: 'highestaudio',
+      highWaterMark: 1 << 25,
+      begin: seconds * 1000,
+    });
+    const resource = createAudioResource(stream, { inlineVolume: true });
+    const currentVolume = this.resource && this.resource.volume ? this.resource.volume.volume : 0.2;
+    resource.volume.setVolume(currentVolume);
+    this.resource = resource;
+    this.player.play(resource);
+    this.starttimestamp = Date.now() - seconds * 1000;
+    this.paused = false;
+  }
+}
+
+module.exports = MusicQueue;

--- a/src/Song.js
+++ b/src/Song.js
@@ -1,0 +1,14 @@
+class Song {
+  constructor({ title, url, totalsec, viewcount, author, thumbnail, type = 'youtube', expiresAt = null }) {
+    this.title = title;
+    this.url = url;
+    this.totalsec = totalsec !== undefined ? Number(totalsec) : null;
+    this.viewcount = viewcount;
+    this.author = author;
+    this.thumbnail = thumbnail;
+    this.type = type;
+    if (expiresAt) this.expiresAt = expiresAt;
+  }
+}
+
+module.exports = Song;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,32 @@
+function toHms(t) {
+    let hms = "";
+    const h = Math.floor(t / 3600);
+    const m = Math.floor((t % 3600) / 60);
+    const s = t % 60;
+    if (h !== 0) {
+        hms = h + ":" + padZero(m) + ":" + padZero(s);
+    } else if (m !== 0) {
+        hms = m + ":" + padZero(s);
+    } else {
+        hms = "0:" + padZero(s);
+    }
+    return hms;
+    function padZero(v) {
+        return v < 10 ? "0" + v : v;
+    }
+}
+
+function parseTime(t) {
+    const parts = t.split(':').map(Number);
+    if (parts.some(isNaN)) return null;
+    if (parts.length === 3) {
+        return parts[0] * 3600 + parts[1] * 60 + parts[2];
+    } else if (parts.length === 2) {
+        return parts[0] * 60 + parts[1];
+    } else if (parts.length === 1) {
+        return parts[0];
+    }
+    return null;
+}
+
+module.exports = { toHms, parseTime };


### PR DESCRIPTION
## Summary
- allow `/play` to queue and stream audio attachments (expire after 2 hours)
- record finished tracks in queue history and replay them via `/history`
- process playlists in 100-track batches with embed progress updates, grouping messages to avoid rate limits and removing worker threads

## Testing
- `node --check index.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5b2b9e3dc832998bb0e39281f70d2