### PR TITLE
Add Japanese and Korean command localizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 ### Official Instance Invite Link
 [Invite your server from here(beta instance)](https://discord.com/api/oauth2/authorize?client_id=887156889455038494&permissions=0&scope=bot%20applications.commands)  
 
-[Invite your server from here(stable instance)](https://discord.com/api/oauth2/authorize?client_id=1133641045813502047&permissions=0&scope=bot%20applications.commands)  
+[Invite your server from here(stable instance)](https://discord.com/api/oauth2/authorize?client_id=1133641045813502047&permissions=0&scope=bot%20applications.commands)
+
+### Language Support
+Commands are available in English, Japanese, and Korean.
 
 ## ja
 2021/09にqiitaで公開した[記事](https://qiita.com/_yussy_/items/d2d809a2da82c5389966)に記載されていたSakuraMusicというbotをDiscord.js v14で書き直したうえで複数の機能を追加したものです。
@@ -113,4 +116,4 @@ node 16.15.0
 npm v9.5.0   
 discord.js 14.11.0  
 @discordjs/voice 0.16.0    
-Tested on windows and linux(ubuntu)  
+Tested on windows and linux(ubuntu)

--- a/src/Commands/Autoplay.js
+++ b/src/Commands/Autoplay.js
@@ -6,6 +6,14 @@ class Autoplay extends BaseCommand {
         super({
             name: 'autoplay',
             description: 'Autoplay the music if the queue is empty',
+            name_localizations: {
+                ja: '自動再生',
+                ko: '자동재생',
+            },
+            description_localizations: {
+                ja: 'キューが空のときに関連曲を自動再生',
+                ko: '큐가 비어 있을 때 자동으로 관련 곡 재생',
+            },
             type: ApplicationCommandType.ChatInput,
         });
     }

--- a/src/Commands/Clear.js
+++ b/src/Commands/Clear.js
@@ -6,6 +6,14 @@ class Clear extends BaseCommand {
         super({
             name: 'clear',
             description: 'Clear the queue',
+            name_localizations: {
+                ja: 'クリア',
+                ko: '초기화',
+            },
+            description_localizations: {
+                ja: 'キューをクリア',
+                ko: '큐를 비웁니다',
+            },
             type: ApplicationCommandType.ChatInput,
         });
     }

--- a/src/Commands/Help.js
+++ b/src/Commands/Help.js
@@ -1,19 +1,29 @@
 const BaseCommand = require('./BaseCommand');
 const { ApplicationCommandType, EmbedBuilder } = require('discord.js');
+const { t } = require('../locale');
 
 class Help extends BaseCommand {
     constructor() {
         super({
             name: 'help',
             description: 'Show the help',
+            name_localizations: {
+                ja: 'ヘルプ',
+                ko: '도움말',
+            },
+            description_localizations: {
+                ja: 'ヘルプを表示',
+                ko: '도움말을 표시',
+            },
             type: ApplicationCommandType.ChatInput,
         });
     }
 
     async execute(interaction, { client }) {
+        const locale = interaction.locale || interaction.guildLocale || 'en';
         const embed = new EmbedBuilder()
-            .setTitle('Help')
-            .setDescription('**play** - Plays a song\n**skip** - Skips a song\n**stop** - Stops the music\n**queue** - Shows the queue\n**nowplaying** - Shows the song that is playing\n**loop** - Loops the queue\n**queueloop** - Loops the queue\n**seek** - Seek to a time in the current song\n**volume** - Changes the volume\n**pause** - Pauses the song\n**resume** - Resumes the song\n**remove** - Removes a song from the queue\n**shuffle** - Shuffles the queue\n**skipto** - Skips to a song in the queue\n**help** - Shows this message\n**ping** - Shows the ping\n**invite** - Invite SakuraMusic v2 to your server\n**autoplay** - Autoplay the music if the queue is empty')
+            .setTitle(t(locale, 'HELP_TITLE'))
+            .setDescription(t(locale, 'HELP_DESCRIPTION'))
             .setFooter({
                 text: 'SakuraMusic v2',
                 iconURL: client.user.displayAvatarURL(),

--- a/src/Commands/History.js
+++ b/src/Commands/History.js
@@ -6,11 +6,27 @@ class History extends BaseCommand {
         super({
             name: 'history',
             description: 'Show playback history or replay a song',
+            name_localizations: {
+                ja: '履歴',
+                ko: '히스토리',
+            },
+            description_localizations: {
+                ja: '再生履歴を表示または再生',
+                ko: '재생 기록을 표시하거나 재생',
+            },
             type: ApplicationCommandType.ChatInput,
             options: [
                 {
                     name: 'index',
                     description: 'History entry to play',
+                    name_localizations: {
+                        ja: '番号',
+                        ko: '번호',
+                    },
+                    description_localizations: {
+                        ja: '再生する履歴項目',
+                        ko: '재생할 기록 항목',
+                    },
                     type: ApplicationCommandOptionType.Integer,
                     required: false
                 }

--- a/src/Commands/Invite.js
+++ b/src/Commands/Invite.js
@@ -6,6 +6,14 @@ class Invite extends BaseCommand {
         super({
             name: 'invite',
             description: 'Invite SakuraMusicV2 to your server',
+            name_localizations: {
+                ja: '招待',
+                ko: '초대',
+            },
+            description_localizations: {
+                ja: 'SakuraMusicV2をサーバーに招待',
+                ko: '서버에 SakuraMusicV2 초대',
+            },
             type: ApplicationCommandType.ChatInput,
         });
     }

--- a/src/Commands/Loop.js
+++ b/src/Commands/Loop.js
@@ -6,6 +6,14 @@ class Loop extends BaseCommand {
         super({
             name: 'loop',
             description: 'Loop the song',
+            name_localizations: {
+                ja: 'ループ',
+                ko: '루프',
+            },
+            description_localizations: {
+                ja: '曲をループ',
+                ko: '곡을 반복 재생',
+            },
             type: ApplicationCommandType.ChatInput,
         });
     }

--- a/src/Commands/NowPlaying.js
+++ b/src/Commands/NowPlaying.js
@@ -7,6 +7,14 @@ class NowPlaying extends BaseCommand {
         super({
             name: 'nowplaying',
             description: 'Show the song you are playing',
+            name_localizations: {
+                ja: '再生中',
+                ko: '현재재생중',
+            },
+            description_localizations: {
+                ja: '再生中の曲を表示',
+                ko: '재생 중인 곡 표시',
+            },
             type: ApplicationCommandType.ChatInput,
         });
     }

--- a/src/Commands/Pause.js
+++ b/src/Commands/Pause.js
@@ -6,6 +6,14 @@ class Pause extends BaseCommand {
         super({
             name: 'pause',
             description: 'Pause the music',
+            name_localizations: {
+                ja: '一時停止',
+                ko: '일시정지',
+            },
+            description_localizations: {
+                ja: '音楽を一時停止',
+                ko: '음악 일시 정지',
+            },
             type: ApplicationCommandType.ChatInput,
         });
     }

--- a/src/Commands/Ping.js
+++ b/src/Commands/Ping.js
@@ -6,6 +6,14 @@ class Ping extends BaseCommand {
         super({
             name: 'ping',
             description: 'Show the ping',
+            name_localizations: {
+                ja: 'ピング',
+                ko: '핑',
+            },
+            description_localizations: {
+                ja: 'pingを表示',
+                ko: '핑 표시',
+            },
             type: ApplicationCommandType.ChatInput,
         });
     }

--- a/src/Commands/Play.js
+++ b/src/Commands/Play.js
@@ -10,17 +10,41 @@ class Play extends BaseCommand {
         super({
             name: 'play',
             description: 'Play music from Youtube or attachment',
+            name_localizations: {
+                ja: '再生',
+                ko: '재생',
+            },
+            description_localizations: {
+                ja: 'Youtubeまたは添付ファイルから音楽を再生',
+                ko: 'YouTube 또는 첨부 파일에서 음악 재생',
+            },
             type: ApplicationCommandType.ChatInput,
             options: [
                 {
                     name: 'video_info',
                     description: 'Youtube URL or Search Query',
+                    name_localizations: {
+                        ja: '動画情報',
+                        ko: '비디오정보',
+                    },
+                    description_localizations: {
+                        ja: 'YoutubeのURLまたは検索クエリ',
+                        ko: 'YouTube URL 또는 검색어',
+                    },
                     type: ApplicationCommandOptionType.String,
                     required: false
                 },
                 {
                     name: 'file',
                     description: 'Audio file attachment',
+                    name_localizations: {
+                        ja: 'ファイル',
+                        ko: '파일',
+                    },
+                    description_localizations: {
+                        ja: '音声ファイルの添付',
+                        ko: '오디오 파일 첨부',
+                    },
                     type: ApplicationCommandOptionType.Attachment,
                     required: false
                 }

--- a/src/Commands/Queue.js
+++ b/src/Commands/Queue.js
@@ -6,6 +6,14 @@ class Queue extends BaseCommand {
         super({
             name: 'queue',
             description: 'Show the queue',
+            name_localizations: {
+                ja: 'キュー',
+                ko: '큐',
+            },
+            description_localizations: {
+                ja: 'キューを表示',
+                ko: '큐 표시',
+            },
             type: ApplicationCommandType.ChatInput,
         });
     }

--- a/src/Commands/QueueLoop.js
+++ b/src/Commands/QueueLoop.js
@@ -6,6 +6,14 @@ class QueueLoop extends BaseCommand {
         super({
             name: 'queueloop',
             description: 'Loop the queue',
+            name_localizations: {
+                ja: 'キューループ',
+                ko: '큐루프',
+            },
+            description_localizations: {
+                ja: 'キューをループ',
+                ko: '큐를 반복 재생',
+            },
             type: ApplicationCommandType.ChatInput,
         });
     }

--- a/src/Commands/Remove.js
+++ b/src/Commands/Remove.js
@@ -6,11 +6,27 @@ class Remove extends BaseCommand {
         super({
             name: 'remove',
             description: 'Remove the song from the queue',
+            name_localizations: {
+                ja: '削除',
+                ko: '제거',
+            },
+            description_localizations: {
+                ja: 'キューから曲を削除',
+                ko: '큐에서 곡을 제거',
+            },
             type: ApplicationCommandType.ChatInput,
             options: [
                 {
                     name: 'songnumber',
                     description: 'Index',
+                    name_localizations: {
+                        ja: '曲番号',
+                        ko: '곡번호',
+                    },
+                    description_localizations: {
+                        ja: '番号',
+                        ko: '인덱스',
+                    },
                     type: ApplicationCommandOptionType.String,
                     required: true,
                 },

--- a/src/Commands/Resume.js
+++ b/src/Commands/Resume.js
@@ -6,6 +6,14 @@ class Resume extends BaseCommand {
         super({
             name: 'resume',
             description: 'Resume the music',
+            name_localizations: {
+                ja: '再開',
+                ko: '재개',
+            },
+            description_localizations: {
+                ja: '音楽を再開',
+                ko: '음악 재개',
+            },
             type: ApplicationCommandType.ChatInput,
         });
     }

--- a/src/Commands/Seek.js
+++ b/src/Commands/Seek.js
@@ -7,11 +7,27 @@ class Seek extends BaseCommand {
         super({
             name: 'seek',
             description: 'Seek to the given time in the current song',
+            name_localizations: {
+                ja: 'シーク',
+                ko: '탐색',
+            },
+            description_localizations: {
+                ja: '現在の曲の指定した時間に移動',
+                ko: '현재 곡의 지정된 시간으로 이동',
+            },
             type: ApplicationCommandType.ChatInput,
             options: [
                 {
                     name: 'position',
                     description: 'Time (seconds or mm:ss)',
+                    name_localizations: {
+                        ja: '時間',
+                        ko: '시간',
+                    },
+                    description_localizations: {
+                        ja: '時間 (秒または mm:ss)',
+                        ko: '시간 (초 또는 mm:ss)',
+                    },
                     type: ApplicationCommandOptionType.String,
                     required: true,
                 },

--- a/src/Commands/Shuffle.js
+++ b/src/Commands/Shuffle.js
@@ -6,6 +6,14 @@ class Shuffle extends BaseCommand {
         super({
             name: 'shuffle',
             description: 'Shuffle the queue',
+            name_localizations: {
+                ja: 'シャッフル',
+                ko: '셔플',
+            },
+            description_localizations: {
+                ja: 'キューをシャッフル',
+                ko: '큐를 섞기',
+            },
             type: ApplicationCommandType.ChatInput,
         });
     }

--- a/src/Commands/Skip.js
+++ b/src/Commands/Skip.js
@@ -6,6 +6,14 @@ class Skip extends BaseCommand {
         super({
             name: 'skip',
             description: 'Skip the music',
+            name_localizations: {
+                ja: 'スキップ',
+                ko: '스킵',
+            },
+            description_localizations: {
+                ja: '音楽をスキップ',
+                ko: '음악을 스킵',
+            },
             type: ApplicationCommandType.ChatInput,
         });
     }

--- a/src/Commands/SkipTo.js
+++ b/src/Commands/SkipTo.js
@@ -6,11 +6,27 @@ class SkipTo extends BaseCommand {
         super({
             name: 'skipto',
             description: 'Skip to the song',
+            name_localizations: {
+                ja: '曲指定スキップ',
+                ko: '특정곡건너뛰기',
+            },
+            description_localizations: {
+                ja: '指定した曲にスキップ',
+                ko: '해당 곡으로 건너뛰기',
+            },
             type: ApplicationCommandType.ChatInput,
             options: [
                 {
                     name: 'songnumber',
                     description: 'Index',
+                    name_localizations: {
+                        ja: '曲番号',
+                        ko: '곡번호',
+                    },
+                    description_localizations: {
+                        ja: '番号',
+                        ko: '인덱스',
+                    },
                     type: ApplicationCommandOptionType.String,
                     required: true,
                 },

--- a/src/Commands/Stop.js
+++ b/src/Commands/Stop.js
@@ -6,6 +6,14 @@ class Stop extends BaseCommand {
         super({
             name: 'stop',
             description: 'Stop the music',
+            name_localizations: {
+                ja: '停止',
+                ko: '정지',
+            },
+            description_localizations: {
+                ja: '音楽を停止',
+                ko: '음악 정지',
+            },
             type: ApplicationCommandType.ChatInput,
         });
     }

--- a/src/Commands/Volume.js
+++ b/src/Commands/Volume.js
@@ -6,11 +6,27 @@ class Volume extends BaseCommand {
         super({
             name: 'volume',
             description: 'Change the volume',
+            name_localizations: {
+                ja: 'ボリューム',
+                ko: '볼륨',
+            },
+            description_localizations: {
+                ja: '音量を変更',
+                ko: '볼륨을 변경',
+            },
             type: ApplicationCommandType.ChatInput,
             options: [
                 {
                     name: 'volume',
                     description: 'Volume',
+                    name_localizations: {
+                        ja: '音量',
+                        ko: '볼륨',
+                    },
+                    description_localizations: {
+                        ja: '音量',
+                        ko: '볼륨',
+                    },
                     type: ApplicationCommandOptionType.String,
                     required: true,
                 },

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,0 +1,21 @@
+const translations = {
+    en: {
+        HELP_TITLE: 'Help',
+        HELP_DESCRIPTION: '**play** - Plays a song\n**skip** - Skips a song\n**stop** - Stops the music\n**queue** - Shows the queue\n**nowplaying** - Shows the song that is playing\n**loop** - Loops the queue\n**queueloop** - Loops the queue\n**seek** - Seek to a time in the current song\n**volume** - Changes the volume\n**pause** - Pauses the song\n**resume** - Resumes the song\n**remove** - Removes a song from the queue\n**shuffle** - Shuffles the queue\n**skipto** - Skips to a song in the queue\n**help** - Shows this message\n**ping** - Shows the ping\n**invite** - Invite SakuraMusic v2 to your server\n**autoplay** - Autoplay the music if the queue is empty',
+    },
+    ja: {
+        HELP_TITLE: 'ヘルプ',
+        HELP_DESCRIPTION: '**play** - 曲を再生\n**skip** - 曲をスキップ\n**stop** - 音楽を停止\n**queue** - キューを表示\n**nowplaying** - 再生中の曲を表示\n**loop** - 曲をループ\n**queueloop** - キューをループ\n**seek** - 現在の曲の再生位置を変更\n**volume** - 音量を変更\n**pause** - 曲を一時停止\n**resume** - 曲を再開\n**remove** - キューから曲を削除\n**shuffle** - キューをシャッフル\n**skipto** - 指定した曲にスキップ\n**help** - このメッセージを表示\n**ping** - pingを表示\n**invite** - SakuraMusic v2をサーバーに招待\n**autoplay** - キューが空のとき関連曲を自動再生',
+    },
+    ko: {
+        HELP_TITLE: '도움말',
+        HELP_DESCRIPTION: '**play** - 노래 재생\n**skip** - 노래 건너뛰기\n**stop** - 음악 정지\n**queue** - 큐 표시\n**nowplaying** - 재생 중인 곡 표시\n**loop** - 곡 반복\n**queueloop** - 큐 반복\n**seek** - 현재 곡의 재생 위치 이동\n**volume** - 볼륨 변경\n**pause** - 곡 일시 정지\n**resume** - 곡 재개\n**remove** - 큐에서 곡 제거\n**shuffle** - 큐 섞기\n**skipto** - 큐의 특정 곡으로 건너뛰기\n**help** - 이 메시지 표시\n**ping** - 핑 표시\n**invite** - SakuraMusic v2를 서버에 초대\n**autoplay** - 큐가 비어 있을 때 자동으로 관련 곡 재생',
+    },
+};
+
+function t(locale, key) {
+    const lang = locale && locale.startsWith('ja') ? 'ja' : locale && locale.startsWith('ko') ? 'ko' : 'en';
+    return translations[lang][key] || translations.en[key];
+}
+
+module.exports = { t };


### PR DESCRIPTION
## Summary
- add locale helper and translations for help command
- localize command names, descriptions, and options for Japanese and Korean
- document language support in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5bb9f5a1c8329a156dedf3bea3b42